### PR TITLE
fix #12 correct servo blocks of KidMotor v4i to make them properly generated

### DIFF
--- a/boards/kidmotor-v4/blocks/blocks_servo.js
+++ b/boards/kidmotor-v4/blocks/blocks_servo.js
@@ -9,15 +9,15 @@ Blockly.defineBlocksWithJsonArray([
       "options": [
         [
           "SV1",
-          "SV1"
+          "servo.SV1"
         ],
         [
           "SV2",
-          "SV2"
+          "servo.SV2"
         ],
         [
           "SV3",
-          "SV3"
+          "servo.SV3"
         ],
       ]
     },


### PR DESCRIPTION
**Serverity**: High
**Reason**: Because of changes to the generator of servo, there is no more `servo.` in front of the servo channel any more. This makes the servo blocks of the KidMotor v4i could not be compiled as expected.
**Resolution**: This commit fix the problem by correcting the servo blocks which overwrites ones of its based (KidBright32).